### PR TITLE
variable xargs, je crois que c'est le dernier !

### DIFF
--- a/includes/cmd.sh
+++ b/includes/cmd.sh
@@ -78,6 +78,7 @@ if [[ "$CMDPATH" == buster ]]; then
 	CMDUSERMOD="/usr/sbin/usermod"
 	CMDWC="/usr/bin/wc"
 	CMDWGET="/usr/bin/wget"
+	CMDXARGS="/usr/bin/xargs"
 	CMDZIP="/usr/bin/zip"
 
 elif [[ "$CMDPATH" == stretch ]]; then
@@ -156,5 +157,6 @@ elif [[ "$CMDPATH" == stretch ]]; then
 	CMDUSERMOD="/usr/sbin/usermod"
 	CMDWC="/usr/bin/wc"
 	CMDWGET="/usr/bin/wget"
+	CMDXARGS="/usr/bin/xargs"
 	CMDZIP="/usr/bin/zip"
 fi

--- a/includes/deb.sh
+++ b/includes/deb.sh
@@ -35,7 +35,6 @@ FONCDEP () {
 	"$CMDWGET" http://mediaarea.net/repo/deb/debian/pubkey.gpg -O mediainfo.gpg && "$CMDAPTKEY" add mediainfo.gpg 2>/dev/null
 
 	"$CMDAPTGET" update -oAcquire::AllowInsecureRepositories=true && "$CMDAPTGET" install -y --allow-unauthenticated deb-multimedia-keyring
-	#"$CMDAPTGET" update && "$CMDAPTGET" install -y --allow-unauthenticated deb-multimedia-keyring
 }
 
 # dépôts standard

--- a/includes/functions.sh
+++ b/includes/functions.sh
@@ -267,7 +267,7 @@ FONCIRSSI () {
 	IRSSIPORT=1"$2"
 	"$CMDMKDIR" -p /home/"$1"/.irssi/scripts/autorun
 	cd /home/"$1"/.irssi/scripts || exit
-	"$CMDCURL" -sL http://git.io/vlcND | "$CMDGREP" -Po '(?<="browser_download_url": ")(.*-v[\d.]+.zip)' | xargs "$CMDWGET" --quiet -O autodl-irssi.zip
+	"$CMDCURL" -sL http://git.io/vlcND | "$CMDGREP" -Po '(?<="browser_download_url": ")(.*-v[\d.]+.zip)' | "$CMDXARGS" "$CMDWGET" --quiet -O autodl-irssi.zip
 	"$CMDUNZIP" -o autodl-irssi.zip
 	command "$CMDRM" autodl-irssi.zip
 	"$CMDCP" -f /home/"$1"/.irssi/scripts/autodl-irssi.pl /home/"$1"/.irssi/scripts/autorun


### PR DESCRIPTION
Encore exécutable oublié ;)
J'ai pas voulu optimiser cmd.sh plus que ça, je préfère garder les deux listes complète pour l'ordre alphabétique, c'est plus pratique pour s'y retrouver.
De toute façon, ce sera réglé avec la prochaine debian, tout sera en /usr/, plus besoin de "if" après normalement.
Ex.